### PR TITLE
Show only categories that map to icons

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -39,10 +39,20 @@ class PagesController < ApplicationController
     "MLB264586"=> nil,
     "MLB1540"=> nil,
     "MLB1953"=> nil}
+
+    @icons_array = @icons_array.select do |_api_id_, icon_class|
+      icon_class.nil? == false
+    end
+
+    @categories = @categories["categories"].select do |category|
+      @icons_array.include?(category["id"])
+    end
+
     @categories_array = [@categories, @icons_array]
   end
 
   private
+
   def request_api
     # url = "https://web.archive.org/web/20220203090926/https://fakestoreapi.com/products/categories"
     url = "https://api.mercadolibre.com/sites/MLB#json"

--- a/app/views/pages/category.html.erb
+++ b/app/views/pages/category.html.erb
@@ -3,7 +3,7 @@
 <% @categories = @categories_array[0]%>
 <% @icons = @categories_array[1]%>
  <% @count = 0 %>
-    <% @categories["categories"].each do |category|%>
+    <% @categories.each do |category|%>
         <% if @count % 5 == 0 %>
           <div class="row justify-content-md-center">
         <% end %>


### PR DESCRIPTION
Fix the categories page so that it only shows the categories that have an icon associated to it.